### PR TITLE
Use hyperspy-base instead of hyperspy as runtime dependency.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
 
@@ -28,7 +28,7 @@ requirements:
     - python >=3.5
     - pyqt
     - traitsui >=6.0
-    - hyperspy >=1.4
+    - hyperspy-base
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

Use "hyperspy-base" instead of "hyperspy" to avoid installing "hyperspy-gui-ipywidgets" and co.
